### PR TITLE
fix with Lua 5.2

### DIFF
--- a/msgpack.lua
+++ b/msgpack.lua
@@ -67,7 +67,7 @@ end
 -- out little endian
 function doubleto8bytes(x)
   local function grab_byte(v)
-    return math.floor(v / 256), tostr(math.mod(math.floor(v), 256))
+    return math.floor(v / 256), tostr(math.fmod(math.floor(v), 256))
   end
   local sign = 0
   if x < 0 then sign = 1; x = -x end


### PR DESCRIPTION
math.mod was deprecated in Lua 5.1 (see LUA_COMPAT_MOD)
